### PR TITLE
Match PDF for Ch 5 Supp Probs and do some renaming

### DIFF
--- a/mbx/index.mbx
+++ b/mbx/index.mbx
@@ -74,7 +74,8 @@ $\cdot$\ \theenumi.]}
 
 
 <rename element="activity" lang="en-US">Problem</rename>
-
+<rename  element="exercise" lang="en-US">Problem</rename>
+<rename element="exercises" lang="en-US">Supplementary Problems</rename>
 <cross-references text="type-global" />
 
 </docinfo>

--- a/mbx/s5-4-suppprobs.mbx
+++ b/mbx/s5-4-suppprobs.mbx
@@ -10,9 +10,9 @@
       </statement>
       <solution>
         <p>
-          We use inclusion and exclusion. Property <m>P_i</m> is that person <m>i</m> gets the prize he or she brought. We are interested in <m>N_{\mbox{e} }(\emptyset)</m>. If <m>P</m> is the set of all properties, we need to compute <m>N_{\mbox{a} }(S)</m> for every subset <m>S</m> of <m>P</m>. But <m>N_{\mbox{a} }(S)</m> is the number of functions from the prizes to the people that give each prize represented by a property in <m>S</m> to the person who brought it. Think in terms of distributing those prizes first. Then there are <m>n-|S|</m> other prizes that we may pass out to the <m>n</m> people as we please, so we may do that in <m>n^{n-|S|}</m> ways. Thus <m>N_{\mbox{a} }(S)=n^{n-|S|}</m>. Applying the formula from <xref ref="compunion" />, we get
+          We use inclusion and exclusion. Let <m>A</m> be the set of all ways to distribute the prizes. Let <m>A_i</m> be the set of distributions in which person <m>i</m> gets the prize he or she brought. We are interested in <m>\left|\overline{\bigcup_{i=1}^n A_i}\right|</m>. We need to compute <m>\left|\bigcap_{i\colon i\in S} A_i\right|</m> for every subset <m>S</m> of <m>[n]</m>. But <m>\left|\bigcap_{i\colon i\in S} A_i\right|</m> is the number of functions from the prizes to the people that assign the prize that person <m>i</m> brhought to person <m>i</m> for each <m>i</m> in the set <m>S</m>. Think in terms of distributing those prizes first. Then there are <m>n-|S|</m> other prizes that we may pass out to the <m>n</m> people as we please, so we may do that in <m>n^{n-|S|}</m> ways. Thus <m>\left|\bigcap_{i\colon i\in S} A_i\right|=n^{n-|S|}</m>. Applying the formula from <xref ref="compunion" />, we get
           <me>
-            N_{\mbox{e} }(\emptyset)=\sum_{S:s\subseteq P}(-1)^{|S|} n^{n-|S|} =
+              \left|\overline{\bigcup_{i=1}^n A_i}\right| =\sum_{S:S\subseteq [n]}(-1)^{|S|} n^{n-|S|} =
             \sum_{s=0}^n (-1)^{|S|}\binom{n}{s}n^{n-s}.
           </me>
         </p>
@@ -26,9 +26,9 @@
       </statement>
       <solution>
         <p>
-          We use inclusion and exclusion. We let property <m>P_i</m> be the property that student <m>i</m> sits in the same seat as before. We are interested in <m>N_{\mbox{e} }(\emptyset)</m>. For this purpose, for each subset <m>S</m> of the set <m>P</m> of all properties, we need to compute <m>N_{\mbox{a} }(S)</m>, the number of ways for the students to return so that every student represented by a property in <m>S</m> sits in his or her previous seat. This leaves us with <m>n-|S|</m> seats to be filled in a one-to-one fashion in <m>m-|S|</m> students. There are <m>(n-|S|)^{\underline{m-|S|}}</m> such seating arrangements, so <m>N_{\mbox{a} }(S)= (n-|S|)^{\underline{m-|S|}}</m>. Thus we have
+          We use inclusion and exclusion. We let <m>A</m> be the set of all seating arrangements. We let <m>A_i</m> be the set of seating arrangements such that student <m>i</m> sits in the same seat as before. We are interested in <m>\left|\overline{\bigcup_{i=1}^n A_i}\right|</m>. For this purpose, for each subset <m>S</m> of the set <m>[n]</m>, we need to compute <m>\left|\bigcap_{i\colon i\in S} A_i\right|</m>, the number of ways for the students to return so that every student represented by an <m>i</m> in <m>S</m> sits in his or her previous seat. This leaves us with <m>n-|S|</m> seats to be filled in a one-to-one fashion by <m>m-|S|</m> students. There are <m>(n-|S|)^{\underline{m-|S|}}</m> such seating arrangements, so <m>\left|\bigcap_{i\colon i\in S} A_i\right|= (n-|S|)^{\underline{m-|S|}}</m>. Thus we have
           <me>
-            N_{\mbox{e} }(\emptyset)=\sum_{S:S\subseteq P}
+              \left|\overline{\bigcup_{i=1}^n A_i}\right|=\sum_{S:S\subseteq [n]}
             (-1)^{|S|}(n-|S|)^{\underline{m-|S|}} = \sum_{s=0}^m (-1)^s\binom{m}{s}(n-s)^{\underline{m-s}}
           </me>
           ways for the students to return so that nobody sits
@@ -39,11 +39,11 @@
 
   <exercise>
       <statement>
-          <p>What is the number of ways to pass out <m>k</m> pieces of candy from an unlimited supply of identical candy to <m>n</m> children (where <m>n</m> is fixed) so that each child gets between three and six pieces of candy (inclusive)? If you have done <xref ref="candy-genfn" /> compare your answer in that problem with your answer in this one.
+          <p>What is the number of ways to pass out <m>k</m> pieces of candy from an unlimited supply of identical candy to <m>n</m> children (where <m>n</m> is fixed) so that each child gets between three and six pieces of candy (inclusive)? If you have done <xref ref="candy-genfn" text="phrase-global" />, compare your answer in that problem with your answer in this one.
           </p>
       </statement>
       <solution>
-          <p>As an inclusion-exclusion problem, we would let property <m>i</m> be that child <m>i</m> gets more than six pieces of candy. We would then observe that the number of ways to pass out the candy so that the children determined by a set <m>S</m> of properties all get more than six pieces, and everyone else gets at least 3, is the number of ways to pass out the remaining candy after giving 7 pieces to each child identified by <m>S</m> and 3 pieces to each other child. This number is <m>\binom{k-7|S|-3(n-|S|)-1}{n-1}=\binom{k-2n-4|S|-1}{n-1}</m>. From here we would substitute into the formula from <xref ref="compunion" />, make any simplifications we could, and we would be done.</p>
+          <p>We could do the problem as a generating functions problem. But, as an inclusion-exclusion problem, we would let <m>A_i</m> be the set of <m>i</m> such that child <m>i</m> gets more than six pieces of candy. We would then observe that the number of ways to pass out the candy so that the children determined by a set <m>S</m> of <m>[n]</m> all get more than six pieces, and everyone else gets at least 3, is the number of ways to pass out the remaining candy after giving 7 pieces to each child identified by <m>S</m> and 3 pieces to each other child. This number is <m>\binom{k-7|S|-3(n-|S|)-1}{n-1}=\binom{k-2n-4|S|-1}{n-1}</m>. From here we would substitute into the formula from <xref ref="compunion" />, make any simplifications we could, and we would be done. This will give the same answer as <xref ref="candy-genfn" text="phrase-global" />.</p>
       </solution>
   </exercise>
   <exercise category="interesting">
@@ -54,12 +54,16 @@
     </statement>
     <solution>
       <p>
-        We use inclusion and exclusion. Let property <m>P_i</m> be that shelf <m>i</m> gets more than <m>m</m> books. Then the number of arrangements of books with at least the properties in a subset <m>S</m> of the set <m>P</m> of all properties is <m>N_{\mbox{a} }(S) = k^{\underline{(m+1)|S|}}n^{\underline{k-(m+1)|S|}}</m>, because in order to have at least the properties in <m>S</m> we may choose <m>(m+1)|S|</m> books and arrange <m>m+1</m> of them on each of the shelves represented by the properties in <m>S</m>, after which we arrange the remainder of the books. Thus
-        <me>
-          N_{\mbox{e} }(\emptyset)=\sum_{S:S\subseteq P} (-1)^{|S|}
-          k^{\underline{(m+1)|S|}}n^{\underline{k-(m+1)|S|}}=\sum_{s=0}^n
-          (-1)^s\binom{n}{s}k^{\underline{(m+1)s}}n^{\underline{k-(m+1)s}}
-        </me>
+        We use inclusion and exclusion. Let property <m>A</m> be the set of all arrangements of the books on the shelves. Let <m>A_i</m> be the set of arrangements in which shelf <m>i</m> gets more than <m>m</m> books. Then the number of arrangements of books in which the shelves determined by a subset <m>S</m> of <m>[n]</m> get more than <m>m</m> books is <m>\left|\bigcap_{i\colon i\in S} A_i\right| = k^{\underline{(m+1)|S|}}n^{\underline{k-(m+1)|S|}}</m>, because in order to get an arrangement in <m>\bigcup_{i\colon i\in S} A_i</m> we may choose <m>(m+1)|S|</m> books and arrange <m>m+1</m> of them on each of the shelves represented by the properties in <m>S</m>, after which we arrange the remainder of the books. Thus
+        <md>
+            <mrow>
+                \left|\overline{\bigcup_{i=1}^n A_i}\right| &amp;=\sum_{S:S\subseteq [n]} (-1)^{|S|}
+          k^{\underline{(m+1)|S|}}n^{\underline{k-(m+1)|S|}}
+            </mrow>
+            <mrow> &amp;=\sum_{s=0}^n
+            (-1)^s\binom{n}{s}k^{\underline{(m+1)s}}n^{\underline{k-(m+1)s}}
+            </mrow>
+        </md>
         is the number of ways to arrange the books so that no shelf gets more than <m>m</m>.
       </p>
     </solution>
@@ -74,12 +78,13 @@
     </statement>
     <solution>
       <p>
-        We use inclusion and exclusion, with property <m>i</m> being the property that child <m>i</m> has the same child to the right the second time they join hands.  Given a set <m>S</m> of properties, we can think of arranging units consisting of individual children and strings of children holding hands in a circle. If we have <m>s</m> properties, then we have <m>n-s</m> of these units. Each string of children can be arranged in only one way, because our set specifies who has to have the same child on the right. Thus <m>N_{\mbox{a} }(S) = (n-s-1)!</m>. This gives us
+          We use inclusion and exclusion, with <m>A</m> being the set of all circular arrangements of the children (where rotation of an arrangement gives the same arrangement, but flipping gives a different arrangement). The set <m>A_i</m> is the set of arrangements such that child <m>i</m> has the same child to the immediate right both times they join hands. Given a set <m>S\subseteq [n]</m>, we can think of arranging units consisting of individual children and strings of children holding hands in a circle. We have <m>n-s</m> of these units because <m>s</m> children are to the immediate right of someone in units of size more than one (and everyone else is leftmost in a unit or not in a string of length 2 or more). Each string of children can be arranged in only one way, because our set specifies who has to have the same child on the right. Thus <m>\left|\bigcap_{i\colon i\in S} A_i\right| = (n-s-1)!</m>. This gives us
         <md>
-          <mrow>N_{\mbox{e} }(\emptyset)=\sum_{S:S\subseteq P}
-          (-1)^{|S|}(n-|S|-1)! =\amp 
+          <mrow>\left|\overline{\bigcup_{i=1}^n A_i}\right| &amp;=\sum_{S:S\subseteq [n]}
+          (-1)^{|S|}(n-|S|-1)!</mrow>
+          <mrow>&amp;=
           \sum_{s=0}^n (-1)^s \binom{n}{s} (n-s-1)!</mrow>
-          <mrow> =\amp \sum_{s=0}^n (-1)^s \frac{n!}{s!(n-s)}</mrow>
+          <mrow> &amp;= \sum_{s=0}^n (-1)^s \frac{n!}{s!(n-s)}</mrow>
         </md>
         ways for the children to join hands the second time so that none
         of them has the same child to the right.
@@ -95,7 +100,7 @@
       </statement>
     <solution>
       <p>
-      We use the Principle of Inclusion and Exclusion. Property <m>P_i</m> will be the property that person <m>i</m> links arms with someone previously to his or her right. (Saying it is the person to the right gives us more control over our formulas.) Given a subset <m>S</m> of the set <m>P</m> of all properties, the number of ways for the people in that set to link arms with the people previously on their right is the number of ways to arrange <m>n-|S|</m> strings of people around a circle with strings of length more than 1 having two ways to arrange themselves.  (Once we have two or more people linked, another person can be added to this string only at one end or not at all, because this person must have been to the right of one of the people on an end of the string. However a string of length two or more can unlink and then link in the opposite order, and each person will still be linked to exactly the same people.) Thus <m>N_{\mbox{a} }(S)= (n-|S|-1)!2^{m(S)}</m>, where <m>m(S)</m> is the number of strings of length more than one determined by <m>S</m>. The number <m>m(S)</m> can be any number from 1 to <m>S</m>, so long as <m>S</m> is not too big; namely so long as <m>|S|\le \lfloor n/1\rfloor</m>. (This is because if <m>m(S)=|S|</m>, then each person determined by a property in <m>S</m> must be adjacent to a person not determined by a property in <m>S</m>.) In particular, <m>N_{\mbox{a} }(S)</m> is not completely determined by the size of <m>S</m>, as in all our other inclusion-exclusion problems. How do we compute <m>m(S)</m>? Let us call a subset <m>R</m> of <m>S</m> a run if
+      We use the Principle of Inclusion and Exclusion. The set <m>A</m> will be the set of arrangements of people in a circle where two arrangements are the same if we get one from the other by rotating or flipping the second. Set <m>A_i</m> will be the set of arrangements in which person <m>i</m> links arms with someone previously to his or her immediate right. (Saying it is the person to the right gives us more control over our formulas.) Given a subset <m>S</m> of <m>[n]</m>, the number of ways for the people in that set to link arms with the people previously on their right is the number of ways to arrange <m>n-|S|</m> strings of people around a circle with strings of length more than 1 having two ways to arrange themselves.  (Once we have two or more people linked, another person can be added to this string only at one end or not at all, because this person must have been to the right of one of the people on an end of the string. However a string of length two or more can unlink and then link in the opposite order, and each person will still be linked to exactly the same people.) Thus <m>\left|\bigcap_{i\colon i\in S}A_i\right|= (n-|S|-1)!2^{m(S)}</m>, where <m>m(S)</m> is the number of strings of length more than one determined by <m>S</m>. The number <m>m(S)</m> can be any number from 1 to <m>S</m>, so long as <m>S</m> is not too big; namely so long as <m>|S|\le \lfloor n/1\rfloor</m>. (This is because if <m>m(S)=|S|</m>, then each person determined by a property in <m>S</m> must be adjacent to a person not determined by a property in <m>S</m>.) In particular, <m>\left|\bigcap_{i\colon i\in S}A_i\right|</m> is not completely determined by the size of <m>S</m>, as in all our other inclusion-exclusion problems. How do we compute <m>m(S)</m>? Let us call a subset <m>R</m> of <m>S</m> a run if
 <ol>
         <li>
           the people determined by <m>R</m> sit together in a
@@ -106,9 +111,9 @@
           people in both seatings.
         </li>
 </ol>
-        Some runs might determine just one person, but a run could also equal all of <m>S</m>. Each run will have one more person not in <m>S</m> who was originally to the right of the person in the run who was rightmost in the first seating, and so this person will have to sit in a row with the people in <m>R</m> in the second seating as well. Thus the number <m>r</m> of runs in <m>S</m> is the number of strings <m>m(S)</m> that may be seated in two ways, and there are <m>n-|S|-r</m> people who do not have to be seated with runs. Thus <m>N_{\mbox{a} }(S) = (n-|S|-1)!2^r</m>, because the total number of strings of people (including strings of just one person) we need to seat is <m>n-|S| -r</m>, and there are <m>(k-1)!</m> ways to arrange <m>k</m> objects in a circle.. If we try to use the information we have so far to compute <m>N_{\mbox{e} }(\emptyset)</m>, we get
+        Some runs might determine just one person, but a run could also equal all of <m>S</m>. Each run will have one more person not in <m>S</m> who was originally to the right of the person in the run who was rightmost in the first seating, and so this person will have to sit in a row with the people in <m>R</m> in the second seating as well. Thus the number <m>r</m> of runs in <m>S</m> is the number of strings <m>m(S)</m> that may be seated in two ways, and there are <m>n-|S|-r</m> people who do not have to be seated with runs. Thus <m>\left|\bigcap_{i\colon i\in S}A_i\right| = (n-|S|-1)!2^r</m>, because the total number of strings of people (including strings of just one person) we need to seat is <m>n-|S| -r</m>, and there are <m>(k-1)!</m> ways to arrange <m>k</m> objects in a circle. If we try to use the information we have so far to compute <m>\left|\overline{\bigcup_{i=1}^n A_i}\right|</m>, we get
         <me>
-          N_{\mbox{e} }(\emptyset)=\sum_{S:S\subseteq P}(-1)^{|S|}(n-|S|_1)!2^r
+            \left|\overline{\bigcup_{i=1}^n A_i}\right| =\sum_{S:S\subseteq [n]}(-1)^{|S|}(n-|S|_1)!2^r
           =\sum_{s=0}^n\sum_{r=1}^{|S|}N(s,r)(n-s-1)!2^r,
         </me>
         in which <m>N(s,r)</m> stands for
@@ -156,7 +161,7 @@
   <exercise category="interesting and difficult">
     <statement>
       <p>
-        (A challenge; the author has not tried to solve this one!) Redo <xref ref="Hora">Problem</xref> in the case that there are <m>n</m> men and <m>n</m> women and when people arrange themselves in a circle they do so alternating gender.
+        (A challenge; the author has not tried to solve this one!) Redo <xref ref="Hora" text="phrase-hybrid" /> in the case that there are <m>n</m> men and <m>n</m> women and when people arrange themselves in a circle they do so alternating gender.
       </p>
     </statement>
   </exercise>


### PR DESCRIPTION
In addition to cleaning up the chapter 5 supplementary problems to match the PDF, I used rename to rename exercise to Problem and exercises to Supplementary Problems.

This closes #81 