### PR TITLE
Formatting problem types pdf

### DIFF
--- a/latex/latex-preamble-styles.tex
+++ b/latex/latex-preamble-styles.tex
@@ -1,0 +1,265 @@
+%%%  This is a set of styles to include in the preamble of the generated latex code for the book Discrete Mathematics: an Open Introduction.
+
+
+% \usepackage{bold-extra}
+% \usepackage{marvosym} %for stop signs.
+% \usepackage{textcomp}
+% \usepackage{multicol}
+
+
+% % FONT OPTIONS (pick one group to uncomment):
+
+%newpx is my current favorite.  This should work on a TEXLive distribution, but on MiKTeX it initially gave me problems.  Running the update wizard to update MiKTeX then showed ``newpx'' as an available package (only since 8/11/15).  Perhaps just synchronizing in the package manager would do the same thing.  Even then, needed to run initexmf --mkmaps from the command line.
+%You could always uncomment all of these to use the default computer modern font.
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{newpxtext}
+\usepackage[vvarbb,cmintegrals,cmbraces,bigdelims]{newpxmath}
+\usepackage[scr=rsfso]{mathalfa}% \mathscr is fancier than \mathcal
+\linespread{1.04}         % adds more leading (space between lines)
+% quantifiers look strange, so change those back to normal:
+	\DeclareSymbolFont{mysymbols}{OMS}{cmsy}{b}{n} %note we make the figures bold to better match newpx.  Replace the ``b'' with an ``m'' to undo this.
+	%\SetSymbolFont{mysymbols}  {bold}{OMS}{cmsy}{b}{n}
+	%\DeclareSymbolFont{myoperators}   {OT1}{cmr} {m}{n}
+	%\SetSymbolFont{myoperators}{bold}{OT1}{cmr} {bx}{n}
+	\DeclareMathSymbol{\forall}{\mathord}{mysymbols}{"38}
+	\DeclareMathSymbol{\exists}{\mathord}{mysymbols}{"39}
+	%\DeclareMathSymbol{\pm}{\mathbin}{mysymbols}{"06}
+	%\DeclareMathSymbol{+}{\mathbin}{myoperators}{"2B}
+	%\DeclareMathSymbol{-}{\mathbin}{mysymbols}{"00}
+	%\DeclareMathSymbol{=}{\mathrel}{myoperators}{"3D}
+
+
+
+%\usepackage[T1]{fontenc}
+%\usepackage{newtxtext,newtxmath}
+
+
+%\usepackage[bitstream-charter]{mathdesign}
+%\usepackage[T1]{fontenc}
+
+%\usepackage[proportional,space,scaled=1.064]{erewhon}
+%\usepackage[erewhon,vvarbb,bigdelims]{newtxmath}
+%\usepackage[T1]{fontenc}
+%\renewcommand*\oldstylenums[1]{\textosf{#1}}
+
+
+
+
+
+% % % % % % Other packages % % % % % % % %
+
+% \usepackage{docmute}
+% \usepackage{pdfpages}
+%
+% \usepackage{svg}
+%
+% \usepackage[framemethod=tikz]{mdframed}
+
+
+
+% % % % % % % % % % % % % %  END OF PACKAGES  % % % % % % % % % % % % % % % % % % %
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%  Nicely styled environments: %%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+%%%%%%%% Problem type markings %%%%%%%%%%%%
+
+% \usepackage{tabto, pdfcomment}
+% \newcommand{\marginsymbol}[2][0]{\tabto*{#1}\makebox[1ex][r]{#2}\tabto*{\TabPrevPos}}
+
+
+
+
+
+
+% %create a mdframe style% \usepackage[bf,sc,center,outermarks]{titlesec}
+%
+%
+% %%%%% FIX FOR BUG IN TITLESEC %%%%%%%%%%%
+% \usepackage{etoolbox}
+%
+% \makeatletter
+% \patchcmd{\ttlh@hang}{\parindent\z@}{\parindent\z@\leavevmode}{}{}
+% \patchcmd{\ttlh@hang}{\noindent}{}{}{}
+% \makeatother
+% %%%%% END FIX %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% \titleformat{\chapter}[display]
+% 	{\Large\filcenter}
+% 	{\rule[4pt]{.3\textwidth}{2pt} \hspace{2ex} \large\textsc{\chaptertitlename} \thechapter \hspace{3ex} \rule[4pt]{0.3\textwidth}{2pt} }
+% 	{1pc}
+% 	{\titlerule\vspace{1ex}\huge\textsc}
+% 	[\vspace{.75ex}\titlerule]
+% \titlespacing*{\chapter}{0pt}{-2em}{2em}
+%
+% \titleformat{\paragraph}[block]
+%   {\normalfont\bfseries\filcenter}
+%   {\theparagraph}
+%   {}
+%   {\textsc} for examples:
+% \mdfdefinestyle{examplestyle}{%
+% 	leftmargin=1.5ex, %left/right margins for oneside
+% 	rightmargin=1.5ex,
+% 	outermargin=1.5ex, %inner/outer margins for twoside
+% 	innermargin=1.5ex,
+% 	innertopmargin=0pt,
+% 	innerbottommargin=1.5ex,
+% 	skipbelow=1.5em,
+% 	roundcorner=0pt,
+% 	topline=false,
+% 	rightline=false,
+%   frametitleaboveskip=2pt,
+% 	frametitlebelowskip=2pt,
+% 	needspace=3em,
+% }
+%
+% %Create indented ``example'' environment:
+% \mdtheorem[style=examplestyle]{mdexample}[theorem]{Example}
+%
+% %Redefine ``example'' to call the new mdexample, and put a paragraph break after it.
+% \renewenvironment{example}{%
+% \mdexample
+% }{%
+% \endmdexample\par
+% }
+%
+%
+% % \LetLtxMacro\mdexample\oldexample
+% % \let\endmdexample\endoldexample
+% %
+% % \newenvironment{mdexample}{%
+% % \oldexample
+% % }{%
+% % \endoldexample\par
+% % }
+%
+% %Create ``investigation'' environment for in-text worksheet type problems:
+% \renewenvironment{investigation}{%
+% \mdfsetup{%
+% 	frametitle={\colorbox{white}{\large\space\space \textit{Investigate!} \space} },
+% 	frametitlealignment=\centering,
+% 	frametitleaboveskip=-1.5ex,
+% 	frametitlebelowskip=0pt,
+% 	frametitlealignment={\hspace*{2pt}},
+% 	innerbottommargin=2em,
+% 	innermargin=1ex,
+% 	outermargin=1ex,
+% 	leftmargin=1ex,
+% 	rightmargin=1ex,
+% %	topline=false,
+% %	bottomline=false,
+% 	linecolor=green!50!black,
+% 	linewidth=1pt,
+% 	skipabove=2em,
+% 	skipbelow=2em,
+% 	roundcorner=15pt,
+% 	needspace=2em,
+% }
+% \vskip 1em
+% \begin{mdframed}
+% }{%
+% \end{mdframed}\vspace{-4em} \begin{center}\colorbox{white}{ \space\space\quad {\LARGE \color{red} \Stopsign} \quad \textbf{Attempt the above activity before proceeding} \quad {\LARGE\color{red} \Stopsign}\quad\space\space }  \end{center}\par
+% }
+%
+%
+% % redefine the assemblage environment for minor tweaking %
+% \renewenvironment{assemblage}[1]{%
+% 	\mdfsetup{%
+% 	frametitle={\colorbox{blue!20}{\space#1\space}},
+% 	% frametitlealignment={\hspace*{1ex}},
+% 	frametitleaboveskip=-1.5ex,
+% 	% frametitlebelowskip=1ex,
+% 	skipabove=2ex,
+% 	skipbelow=1em,
+% 	roundcorner=1pt,
+% 	leftmargin=3pt,
+% 	rightmargin=3pt,
+% 	backgroundcolor=blue!5,
+% 	linecolor=blue!30,
+% 	linewidth=1.5pt,
+% 	innertopmargin=-.5ex,
+% 	innerbottommargin=1.15em,
+% 	needspace=2em,
+% }
+% \begin{mdframed}\par\medskip
+% }{%
+% \end{mdframed}\par
+% }
+%
+% %%%%%%%%%%%%%%%%%  End environments %%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+%
+% % use QED to end proofs:
+% \renewcommand{\qedsymbol}{\textsc{qed}}
+%
+%
+% %%%%%%%% Set description list spacing the way I want %%%%%%%%%%%%%%%
+% \setlist[description]{style=nextline, leftmargin=3em}
+%
+%
+% %%%%%%% Set chapters to start at 0 %%%%%%%%%%%%%%%%%%%%%%%%%%%
+% \setcounter{chapter}{-1}
+
+
+%Fix widows and orphans (single lines at top/bottom of page):
+\clubpenalty=10000
+\widowpenalty=10000
+\raggedbottom
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%  Headers and footers %%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\renewcommand{\chaptermark}[1]{\markboth{\thechapter.\ #1}{}} %Removes word "chapter" from the \leftmark.
+
+\fancyhead{} % clear header fields
+\fancyhead[LE]{{\footnotesize \textsl{\thepage}}~~ \textsc{\scriptsize \nouppercase{\leftmark}}}
+\fancyhead[RO]{\textsc{\scriptsize \nouppercase{\rightmark}} ~~ {\footnotesize \textsl{\thepage}}  }
+\fancyfoot{}
+
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%    Chapter headings  %%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% \usepackage[bf,sc,center,outermarks]{titlesec}
+%
+%
+% %%%%% FIX FOR BUG IN TITLESEC %%%%%%%%%%%
+% \usepackage{etoolbox}
+%
+% \makeatletter
+% \patchcmd{\ttlh@hang}{\parindent\z@}{\parindent\z@\leavevmode}{}{}
+% \patchcmd{\ttlh@hang}{\noindent}{}{}{}
+% \makeatother
+% %%%%% END FIX %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%
+% \titleformat{\chapter}[display]
+% 	{\Large\filcenter}
+% 	{\rule[4pt]{.3\textwidth}{2pt} \hspace{2ex} \large\textsc{\chaptertitlename} \thechapter \hspace{3ex} \rule[4pt]{0.3\textwidth}{2pt} }
+% 	{1pc}
+% 	{\titlerule\vspace{1ex}\huge\textsc}
+% 	[\vspace{.75ex}\titlerule]
+% \titlespacing*{\chapter}{0pt}{-2em}{2em}
+%
+% \titleformat{\paragraph}[block]
+%   {\normalfont\bfseries\filcenter}
+%   {\theparagraph}
+%   {}
+%   {\textsc}
+%%%%%%%%%  End chapter/sectio headings %%%%%%%%%%%%%%%%%
+
+%%% End of File.

--- a/mbx/s4-3-genfn-recurrence.mbx
+++ b/mbx/s4-3-genfn-recurrence.mbx
@@ -82,7 +82,7 @@
         </statement>
         <hint>
             <p>
-                You may run into a product of the form <m>\sum_{i=0}^\infty a^ix^i\sum_{j=0}^\infty b^jx^j</m>. Note that in the product, the coefficient of <m>x^k</m> is <m>\sum_{i=0}^k a^ib^{k-i} = \sum_{i=0}^k \frac{a^i}{b^i}</m>. 
+                You may run into a product of the form <m>\sum_{i=0}^\infty a^ix^i\sum_{j=0}^\infty b^jx^j</m>. Note that in the product, the coefficient of <m>x^k</m> is <m>\sum_{i=0}^k a^ib^{k-i} = \sum_{i=0}^k \frac{a^i}{b^i}</m>.
             </p>
         </hint>
         <solution>
@@ -153,7 +153,7 @@
         <p>The sequence of problems that follows (culminating in <xref ref="solveFibonacci" />) describes a number of hypotheses we might make about a fictional population of rabbits. We use the example of a rabbit population for historic reasons; our goal is a classical sequence of numbers called Fibonacci numbers. When Fibonacci<fn>Apparently Leanardo de Pisa was given the name Fibonacci posthumously. It is a shortening of <q>son of Bonacci</q> in Italian.</fn> introduced them, he did so with a fictional population of rabbits.<idx><h>Fibonacci numbers</h></idx>
         </p>
     </paragraphs>
-    
+
     <activity xml:id="secondorderintroduction" category="essential">
       <statement>
         <p>Suppose we start (at the end of month 0) with 10 pairs of baby rabbits, and that after baby rabbits mature for one month they begin to reproduce, with each pair producing two new pairs at the end of each month afterwards. Suppose further that over the time we observe the rabbits, none die. Let <m>a_n</m> be the number of rabbits we have at the end of month <m>n</m>. Show that <m>a_n=a_{n-1} + 2a_{n-2}</m>. This is an example of a <term>second order</term><idx><h>recurrence</h><h>second order</h></idx><idx><h>second order recurrence</h></idx> <em>linear</em><idx><h>recurrence</h><h>linear</h></idx><idx><h>linear recurrence</h><h>second order</h></idx> recurrence with constant coefficients.<idx><h>recurrence</h><h>constant coefficient</h></idx> Using a method similar to that of <xref ref="substituteandsolve">Problem</xref>, show that
@@ -463,7 +463,7 @@
         </task>
         <task category="important">
             <statement>
-                <p>Find an algebraic explanation (not using the recurrence equation) of what happens to make the square roots of five go away. 
+                <p>Find an algebraic explanation (not using the recurrence equation) of what happens to make the square roots of five go away.
                 </p>
             </statement>
             <hint>
@@ -579,7 +579,7 @@
                         <mrow>\sum_{n=0}^\infty C_nx^n
                         \amp= 1+x\sum_{i=1}^\infty C_{i-1}x^{i-1}\sum_{j=0}^\infty C_{j}x^{j}</mrow>
                         <mrow>y \amp= 1 + xy^2</mrow>
-                    </md>. This gives us <m>xy^2-y+1=0</m>, and solving for <m>y</m> by the quadratic formula gives us <m>y=\frac{1\pm \sqrt{1-4x}}{2x}</m>. 
+                    </md>. This gives us <m>xy^2-y+1=0</m>, and solving for <m>y</m> by the quadratic formula gives us <m>y=\frac{1\pm \sqrt{1-4x}}{2x}</m>.
         </p>
             </solution>
         </task>


### PR DESCRIPTION
I've managed to get the problem type symbols in the left margin in the pdf.  Now that I know how to do this, I should be able to tackle the html in a similar way, which I'll try this afternoon.  Oh, and in acrobat, the symbols should have useful tooltips (although I haven't tested this).

This pull request also includes some formatting of the font and page headers to make it look nice (to my eyes).  To get the font/header formatting, you need to put the latex-preamble-style.tex file in the directory you compile your latex inside.