### PR TITLE
Add problem types for html and exercises.

### DIFF
--- a/html/custom-styles.css
+++ b/html/custom-styles.css
@@ -1,0 +1,46 @@
+/* This is the custom css file for Bogart's Combinatorics through Guided Discovery, mainly to insert problem type symbols */
+
+.essential::before {
+  display: inline!important;
+  content: "\2022";
+}
+
+.motivation::before {
+  display: inline!important;
+  content: "\00b0";
+}
+
+.summary::before {
+  display: inline!important;
+  content: "\002b";
+}
+
+.interesting::before {
+  display: inline!important;
+  content: "\21D2";
+}
+
+.difficult::before {
+  display: inline!important;
+  content: "\002a";
+}
+
+.forward-essential::before{
+  display: inline!important;
+  content: "\22C5";
+}
+
+.interesting-forward-essential::before{
+  display: inline!important;
+  content: "\21D2 \22C5";
+}
+
+.interesting-essential::before{
+  display: inline!important;
+  content: "\21D2 \2022";
+}
+
+.interesting-difficult::before{
+  display: inline!important;
+  content: "\21D2 \002a";
+}

--- a/xsl/custom-html.xsl
+++ b/xsl/custom-html.xsl
@@ -181,7 +181,7 @@
   </xsl:choose>
 </xsl:template>
 
-<xsl:template match="task" mode="body-css-class">
+<xsl:template match="task or exercise" mode="body-css-class">
   <xsl:choose>
     <xsl:when test="@category='essential'">
       <xsl:text>exercise-like essential</xsl:text>

--- a/xsl/custom-html.xsl
+++ b/xsl/custom-html.xsl
@@ -181,7 +181,7 @@
   </xsl:choose>
 </xsl:template>
 
-<xsl:template match="task or exercise" mode="body-css-class">
+<xsl:template match="task|exercise" mode="body-css-class">
   <xsl:choose>
     <xsl:when test="@category='essential'">
       <xsl:text>exercise-like essential</xsl:text>

--- a/xsl/custom-html.xsl
+++ b/xsl/custom-html.xsl
@@ -145,5 +145,77 @@
 
 
 
+<!-- Hack classes to allow for display of problem type markers -->
+<xsl:template match="activity" mode="body-css-class">
+  <xsl:choose>
+    <xsl:when test="@category='essential'">
+      <xsl:text>example-like essential</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='motivation'">
+      <xsl:text>example-like motivation</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='summary'">
+      <xsl:text>example-like summary</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='interesting'">
+      <xsl:text>example-like interesting</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='difficult'">
+      <xsl:text>example-like difficult</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='essential for this or the next section'">
+      <xsl:text>example-like forward-essential</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='essential for this or the next section, and interesting'">
+      <xsl:text>example-like interesting-forward-essential</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='important and interesting'">
+      <xsl:text>example-like interesting-essential}</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='interesting and difficult'">
+      <xsl:text>example-like interesting-difficult}</xsl:text>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:text>example-like</xsl:text>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template match="task" mode="body-css-class">
+  <xsl:choose>
+    <xsl:when test="@category='essential'">
+      <xsl:text>exercise-like essential</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='motivation'">
+      <xsl:text>exercise-like motivation</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='summary'">
+      <xsl:text>exercise-like summary</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='interesting'">
+      <xsl:text>exercise-like interesting</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='difficult'">
+      <xsl:text>exercise-like difficult</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='essential for this or the next section'">
+      <xsl:text>exercise-like forward-essential</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='essential for this or the next section, and interesting'">
+      <xsl:text>exercise-like interesting-forward-essential</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='important and interesting'">
+      <xsl:text>exercise-like interesting-essential}</xsl:text>
+    </xsl:when>
+    <xsl:when test="@category='interesting and difficult'">
+      <xsl:text>exercise-like interesting-difficult}</xsl:text>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:text>exercise-like</xsl:text>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+
 
 </xsl:stylesheet>

--- a/xsl/custom-latex.xsl
+++ b/xsl/custom-latex.xsl
@@ -301,6 +301,85 @@
 
 
 
+<xsl:template match="exercises/exercise|exercisegroup/exercise">
+    <!-- Start a list right before first exercise of subdivision, or of exercise group -->
+    <xsl:choose>
+        <xsl:when test="not(preceding-sibling::exercise) and parent::exercisegroup">
+            <xsl:text>\begin{exercisegroup}(</xsl:text>
+            <xsl:choose>
+                <xsl:when test="not(../@cols)">
+                    <xsl:text>1</xsl:text>
+                </xsl:when>
+                <xsl:when test="../@cols = 1 or ../@cols = 2 or ../@cols = 3 or ../@cols = 4 or ../@cols = 5 or ../@cols = 6">
+                    <xsl:value-of select="../@cols"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:message terminate="yes">MBX:ERROR: invalid value <xsl:value-of select="../@cols" /> for cols attribute of exercisegroup</xsl:message>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>)&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="not(preceding-sibling::exercise) and parent::exercises">
+            <xsl:text>\begin{exerciselist}&#xa;</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+    <xsl:choose>
+        <xsl:when test="parent::exercises">
+            <xsl:text>\item[</xsl:text>
+        </xsl:when>
+        <xsl:when test="parent::exercisegroup">
+            <xsl:text>\exercise[</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+    <xsl:apply-templates select="." mode="serial-number" />
+    <xsl:text>.]</xsl:text>
+    <!-- Start added problem type code: -->
+    <xsl:text>\marginsymbol[-1em]{</xsl:text>
+    <xsl:call-template name="problem-type" />
+    <xsl:text>} </xsl:text>
+    <!-- End added problem type code  -->
+    <xsl:apply-templates select="." mode="label"/>
+    <xsl:if test="title">
+        <xsl:text>(</xsl:text>
+        <xsl:apply-templates select="." mode="title-full"/>
+        <xsl:text>)\space\space{}</xsl:text>
+    </xsl:if>
+    <!-- condition on webwork wrapper or not -->
+    <xsl:choose>
+        <xsl:when test="webwork">
+            <xsl:apply-templates select="introduction" />
+            <xsl:apply-templates select="webwork" />
+            <xsl:apply-templates select="conclusion" />
+        </xsl:when>
+        <xsl:otherwise>
+        <!-- Order enforced: statement, hint, answer, solution -->
+            <xsl:if test="$exercise.text.statement='yes'">
+                <xsl:apply-templates select="statement" />
+                <xsl:if test="not(parent::exercisegroup)">
+                    <xsl:text>\par\smallskip&#xa;</xsl:text>
+                </xsl:if>
+            </xsl:if>
+            <xsl:if test="hint and $exercise.text.hint='yes'">
+                <xsl:apply-templates select="hint" />
+            </xsl:if>
+            <xsl:if test="answer and $exercise.text.answer='yes'">
+                <xsl:apply-templates select="answer" />
+            </xsl:if>
+            <xsl:if test="solution and $exercise.text.solution='yes'">
+                <xsl:apply-templates select="solution" />
+            </xsl:if>
+        </xsl:otherwise>
+    </xsl:choose>
+    <!-- close list if no more exercise in subdivision or in exercise group -->
+    <xsl:choose>
+        <xsl:when test="not(following-sibling::exercise) and parent::exercisegroup">
+            <xsl:text>\end{exercisegroup}&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:when test="not(following-sibling::exercise) and parent::exercises">
+            <xsl:text>\end{exerciselist}&#xa;</xsl:text>
+        </xsl:when>
+    </xsl:choose>
+</xsl:template>
 
 
 </xsl:stylesheet>

--- a/xsl/custom-latex.xsl
+++ b/xsl/custom-latex.xsl
@@ -157,7 +157,7 @@
       <xsl:text>\pdftooltip{\tiny$+$}{summary}</xsl:text>
     </xsl:when>
     <xsl:when test="@category='interesting'">
-      <xsl:text>\pdftooltip{\importantarrow}{especially intersting}</xsl:text>
+      <xsl:text>\pdftooltip{\importantarrow}{especially interesting}</xsl:text>
     </xsl:when>
     <xsl:when test="@category='difficult'">
       <xsl:text>\pdftooltip{$*$}{difficult}</xsl:text>


### PR DESCRIPTION
Here is my attempt to add the problem type symbols to the html version: https://oscarlevin.github.io/ibl-combinatorics/html/index.html.

I also added them to the supplemental problems sections in both pdf and html.