### PR TITLE
Remove paragraphs

### DIFF
--- a/mbx/s1-2-basics.mbx
+++ b/mbx/s1-2-basics.mbx
@@ -1,5 +1,6 @@
 <section>
   <title>Basic Counting Principles</title>
+  <introduction>
   <activity xml:id="fiveteamtournament" category="motivation">
       <statement>
         <p>
@@ -413,10 +414,10 @@
         </p>
       </solution>
     </activity>
+</introduction>
 
 
-
-  <paragraphs>
+  <subsection>
     <title>The sum and product principles</title>
     <p>
       These problems
@@ -639,7 +640,6 @@ many ways can you pair up the next person who isn't already paired up?
         </solution>
       </task>
     </activity>
-</paragraphs>
 
     <activity xml:id="generalproductprinciple" category="summary">
       <statement>
@@ -877,8 +877,8 @@ many ways can you pair up the next person who isn't already paired up?
         </p>
       </solution>
     </activity>
-
-  <paragraphs>
+  </subsection>
+  <subsection>
     <title>Functions and directed graphs</title>
     <p>
       As another example how standard mathematical language relates to
@@ -928,10 +928,8 @@ many ways can you pair up the next person who isn't already paired up?
     </p>
 
 <todo>
-    <p>
-      <em>The figure needs to have part (e) added to it.</em>
-    </p>
-    </todo>
+The figure needs to have part (e) added to it.
+</todo>
 
     <p>
       Notice that there is a simple test for whether a digraph whose vertices
@@ -944,7 +942,7 @@ many ways can you pair up the next person who isn't already paired up?
       <m>S</m> to <m>S</m> and draw only one set of vertices representing the elements
       of <m>S</m>.) For further discussion of functions and digraphs see <xref ref="functionrelation">Sections</xref> and <xref ref="relationdigraph"></xref> of {<xref ref="Relations">Appendix</xref>}.
     </p>
-  </paragraphs>
+
 
     <activity category="motivation">
       <statement>
@@ -1155,9 +1153,9 @@ many ways can you pair up the next person who isn't already paired up?
       very little difference between the idea of a permutation of <m>S</m> and an
       <m>n</m>-element permutation of <m>S</m> when <m>n</m> is the size of <m>S</m>.
     </p>
+  </subsection>
 
-
-  <paragraphs>
+  <subsection>
     <title>The bijection principle</title>
     <p>
       Another name for a one-to-one
@@ -1182,9 +1180,9 @@ many ways can you pair up the next person who isn't already paired up?
       principle guides us into finding insight into some otherwise
       very complicated proofs.
     </p>
-  </paragraphs>
+  </subsection>
 
-  <paragraphs>
+  <subsection>
     <title>Counting subsets of a set</title>
     <activity xml:id="SubsetsBinaryRepresentation">
       <statement>
@@ -1328,9 +1326,9 @@ many ways can you pair up the next person who isn't already paired up?
         </solution>
       </task>
     </activity>
-  </paragraphs>
+  </subsection>
 
-  <paragraphs>
+  <subsection>
     <title>Pascal's Triangle</title>
     <p>
       The Pascal Equation that you derived in <xref ref="Pascal">Problem</xref>
@@ -1860,9 +1858,9 @@ many ways can you pair up the next person who isn't already paired up?
       similar to those we used in proving the Pascal Equation, at the
       beginning of <xref ref="InductionRecursion">Chapter</xref>.
     </p>
-  </paragraphs>
+  </subsection>
 
-  <paragraphs>
+  <subsection>
     <title>The quotient principle</title>
     <activity xml:id="twelvechoosethree" category="essential">
         <introduction>
@@ -2047,7 +2045,6 @@ many ways can you pair up the next person who isn't already paired up?
       more detail in order to tease out another counting principle that we
       can use in a wide variety of situations.
     </p>
-</paragraphs>
 
     <table xml:id="tab_permsof3" >
       <caption>The <m>3</m>-element permutations of <m>\{a,b,c,d,e\}</m> organized
@@ -2533,4 +2530,6 @@ many ways can you pair up the next person who isn't already paired up?
         </p>
       </statement>
     </activity>
+    </subsection>
+
 </section>

--- a/mbx/s4-3-genfn-recurrence.mbx
+++ b/mbx/s4-3-genfn-recurrence.mbx
@@ -145,14 +145,14 @@
   </subsection>
 
 
-  <subsection>
-    <title>Second order linear recurrence relations</title>
-
-    <paragraphs>
+    <subsection>
         <title>Fibonacci numbers</title>
         <p>The sequence of problems that follows (culminating in <xref ref="solveFibonacci" />) describes a number of hypotheses we might make about a fictional population of rabbits. We use the example of a rabbit population for historic reasons; our goal is a classical sequence of numbers called Fibonacci numbers. When Fibonacci<fn>Apparently Leanardo de Pisa was given the name Fibonacci posthumously. It is a shortening of <q>son of Bonacci</q> in Italian.</fn> introduced them, he did so with a fictional population of rabbits.<idx><h>Fibonacci numbers</h></idx>
         </p>
-    </paragraphs>
+    </subsection>
+  <subsection>
+    <title>Second order linear recurrence relations</title>
+
 
     <activity xml:id="secondorderintroduction" category="essential">
       <statement>

--- a/mbx/s6-3-polya.mbx
+++ b/mbx/s6-3-polya.mbx
@@ -108,7 +108,7 @@
             <solution>
                 <p><md>
                     <mrow>
-                        &amp;\{RRRRRR\}</mrow>,
+                        &amp;\{RRRRRR\},</mrow>
 <mrow>&amp;\{RRRRRB, BRRRRR, RBRRRR, RRBRRR, RRRBRR, RRRRBR\},</mrow> <mrow>&amp;\{RRRRBB, BRRRRB, BBRRRR, RBBRRR, RRBBRR, RRRBBR\},</mrow> <mrow>&amp;\{RRRBRB, BRRRBR, RBRRRB, BRBRRR, RBRBRR, RRBRBR\},</mrow> <mrow>&amp;\{RRBRRB, BRRBRR, RBRRBR\},</mrow>
 <mrow>&amp;\{RRRBBB, BRRRBB, BBRRRB, BBBRRR, RBBBRR, RRBBBR\},</mrow> <mrow>&amp;\{RRBRBB, BRRBRB, BBRRBR, RBBRRB, BRBBRR, RBRBBR\},</mrow> <mrow>&amp;\{RRBBRB, BRRBBR, RBRRBB, BRBRRB, BBRBRR, RBBRBR\},</mrow> <mrow>&amp;\{RBRBRB, BRBRBR\},</mrow>
 <mrow>&amp;\{RRBBBB, BRRBBB, BBRRBB, BBBRRB, BBBBRR, RBBBBR\},</mrow> <mrow>&amp;\{RBRBBB, BRBRBB, BBRBRB, BBBRBR, RBBBRB, BRBBBR\},</mrow> <mrow>&amp;\{RBBRBB, BRBBRB, BBRBBR\},</mrow>


### PR DESCRIPTION
Because there were some activity elements floating around outside of subsections in 1.2 when I was working on it at some point, I elected to just convert the subsection elements to paragraphs elements. Of course, that removed numbering for subsections, making it inconsistent with the official PDF. (I did it at at time when we weren't numbering subsections, so I figured it was "safe". Now that that's changed, it's no longer safe.) I've gone back and fixed that and one spot in 4.3 where there's some really weird subsection structure surrounding Fibonacci numbers. (What is the point of subsection 4.3.2?)

I also caught a validation error that I introduced in 6.3 when trying to resolve the egregious overfull hboxes. That's fixed in this PR as well.

Trying not to turn radioactive in the vicinity of Hanford (visiting a collaborator at PNNL) through next Tuesday (traveling next Wednesday), so (a) I'm on Pacific time and feeling confused by when y'all are working and (b) likely focusing on other things.