### PR TITLE
Backmatter

### DIFF
--- a/html/custom-styles.css
+++ b/html/custom-styles.css
@@ -1,46 +1,170 @@
 /* This is the custom css file for Bogart's Combinatorics through Guided Discovery, mainly to insert problem type symbols */
 
-.essential::before {
-  display: inline!important;
+.example-like.essential::before {
+  display: inline-block!important;
   content: "\2022";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
 }
 
-.motivation::before {
-  display: inline!important;
+.example-like.motivation::before {
+  display: inline-block!important;
   content: "\00b0";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
 }
 
-.summary::before {
-  display: inline!important;
+.example-like.summary::before {
+  display: inline-block!important;
   content: "\002b";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
 }
 
-.interesting::before {
-  display: inline!important;
+.example-like.interesting::before {
+  display: inline-block!important;
   content: "\21D2";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
 }
 
-.difficult::before {
-  display: inline!important;
+.example-like.difficult::before {
+  display: inline-block!important;
   content: "\002a";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
 }
 
-.forward-essential::before{
-  display: inline!important;
+.example-like.forward-essential::before{
+  display: inline-block!important;
   content: "\22C5";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
 }
 
-.interesting-forward-essential::before{
-  display: inline!important;
+.example-like.interesting-forward-essential::before{
+  display: inline-block!important;
   content: "\21D2 \22C5";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
 }
 
-.interesting-essential::before{
-  display: inline!important;
+.example-like.interesting-essential::before{
+  display: inline-block!important;
   content: "\21D2 \2022";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
 }
 
-.interesting-difficult::before{
-  display: inline!important;
+.example-like.interesting-difficult::before{
+  display: inline-block!important;
   content: "\21D2 \002a";
+  position: relative;
+  left: -1.5em;
+  margin: -2pt;
+  width: 0;
+}
+
+
+/*Tasks:*/
+
+.exercise-like.essential::before {
+  display: inline-block!important;
+  content: "\2022";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.exercise-like.motivation::before {
+  display: inline-block!important;
+  content: "\00b0";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.exercise-like.summary::before {
+  display: inline-block!important;
+  content: "\002b";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.exercise-like.interesting::before {
+  display: inline-block!important;
+  content: "\21D2";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.exercise-like.difficult::before {
+  display: inline-block!important;
+  content: "\002a";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.exercise-like.forward-essential::before{
+  display: inline-block!important;
+  content: "\22C5";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.exercise-like.interesting-forward-essential::before{
+  display: inline-block!important;
+  content: "\21D2 \22C5";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.exercise-like.interesting-essential::before{
+  display: inline-block!important;
+  content: "\21D2 \2022";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.exercise-like.interesting-difficult::before{
+  display: inline-block!important;
+  content: "\21D2 \002a";
+  position: relative;
+  left: -1em;
+  margin: -1pt;
+  width: 0;
+}
+
+.example-like .exercise-like {
+  margin-left: 1.5em;
 }

--- a/mbx/app1-2-equivrelations.mbx
+++ b/mbx/app1-2-equivrelations.mbx
@@ -345,7 +345,7 @@
         <statement>
           <p>
             Suppose that <m>R</m> is an equivalence relation on a set <m>X</m>
-            and for each <m>x\in X</m>, let <m>C_x = \{y| y\in X \mbox{ and }
+            and for each <m>x\in X</m>, let <m>C_x = \{y| y\in X \text{ and }
             yRx\}</m>. If <m>C_x</m> and
             <m>C_z</m> have an element <m>y</m> in common, what can you conclude
             about <m>C_x</m> and <m>C_z</m> (besides the fact that they have an
@@ -635,9 +635,7 @@
           <p>
             The equivalence classes are
             <me>
-              \{RRBB, BRRB, BBRR, RBBR\}
-              \mbox{~and~}
-              \{RBRB, BRBR\}.
+              \{RRBB, BRRB, BBRR, RBBR\} \text{ and } \{RBRB, BRBR\}.
             </me>
           </p>
 

--- a/mbx/app3-4-prodprinc.mbx
+++ b/mbx/app3-4-prodprinc.mbx
@@ -138,8 +138,7 @@
     <solution>
         <p>
             <me>
-        \sum_{i,j\mbox{:\ }
-        i+j=n} n!\frac{a_i}{i!}\frac{b_j}{j!},
+        \sum_{i,j:\ i+j=n} n!\frac{a_i}{i!}\frac{b_j}{j!},
       </me>
         which can be better
         written as

--- a/mbx/app3-5-expformula.mbx
+++ b/mbx/app3-5-expformula.mbx
@@ -567,7 +567,7 @@
           all compositions of <m>n</m> into <m>j</m> parts becomes
           <me>
             \sum_{j=1}^n \frac{n!}{j}(-1)^j\sum_{{p_1,p_2,\ldots,p_n: \sum_{r=1}^n
-            rp_r =n \atop \mbox{and}  \sum_{r=1}^n p_r =j}}\binom{j}{p_1, p_2, \ldots,
+            rp_r =n \atop \text{ and }  \sum_{r=1}^n p_r =j}}\binom{j}{p_1, p_2, \ldots,
             p_n}
             \prod_{r=1}^n\frac{2^{{\binom{r}{2}p_r}}
             }{(r!)^{p_r}}.

--- a/mbx/gfdl-mathbook.mbx
+++ b/mbx/gfdl-mathbook.mbx
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--********************************************************************
+Copyright 2015-2016 Robert A. Beezer
+
+This file is part of MathBook XML.
+
+MathBook XML is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 or version 3 of the
+License (at your option).
+
+MathBook XML is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
+*********************************************************************-->
+
+<!-- This is a faithful copy of Version 1.3 of the GFDL. -->
+<!-- The copyright assertion above only refers to the    -->
+<!-- addition of the MathBook XML elements employed to   -->
+<!-- render the license within a MathBook XML document   -->
+
+<appendix xml:id="appendix-gfdl">
+    <title>GNU Free Documentation License</title>
+
+    <paragraphs>
+        <p>Version 1.3, 3 November 2008</p>
+
+        <p>Copyright <copyright /> 2000, 2001, 2002, 2007, 2008 Free Software Foundation, Inc. <less /><url href="http://www.fsf.org/" /><greater /></p>
+
+        <p>Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section0">
+        <title>0. PREAMBLE</title>
+
+        <p>The purpose of this License is to make a manual, textbook, or other functional and useful document <q>free</q> in the sense of freedom: to assure everyone the effective freedom to copy and redistribute it, with or without modifying it, either commercially or noncommercially. Secondarily, this License preserves for the author and publisher a way to get credit for their work, while not being considered responsible for modifications made by others.</p>
+
+        <p>This License is a kind of <q>copyleft</q>, which means that derivative works of the document must themselves be free in the same sense. It complements the GNU General Public License, which is a copyleft license designed for free software.</p>
+
+        <p>We have designed this License in order to use it for manuals for free software, because free software needs free documentation: a free program should come with manuals providing the same freedoms that the software does. But this License is not limited to software manuals; it can be used for any textual work, regardless of subject matter or whether it is published as a printed book. We recommend this License principally for works whose purpose is instruction or reference.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section1">
+        <title>1. APPLICABILITY AND DEFINITIONS</title>
+
+        <p>This License applies to any manual or other work, in any medium, that contains a notice placed by the copyright holder saying it can be distributed under the terms of this License. Such a notice grants a world-wide, royalty-free license, unlimited in duration, to use that work under the conditions stated herein. The <q>Document</q>, below, refers to any such manual or work. Any member of the public is a licensee, and is addressed as <q>you</q>. You accept the license if you copy, modify or distribute the work in a way requiring permission under copyright law.</p>
+
+        <p>A <q>Modified Version</q> of the Document means any work containing the Document or a portion of it, either copied verbatim, or with modifications and/or translated into another language.</p>
+
+        <p>A <q>Secondary Section</q> is a named appendix or a front-matter section of the Document that deals exclusively with the relationship of the publishers or authors of the Document to the Document's overall subject (or to related matters) and contains nothing that could fall directly within that overall subject. (Thus, if the Document is in part a textbook of mathematics, a Secondary Section may not explain any mathematics.) The relationship could be a matter of historical connection with the subject or with related matters, or of legal, commercial, philosophical, ethical or political position regarding them.</p>
+
+        <p>The <q>Invariant Sections</q> are certain Secondary Sections whose titles are designated, as being those of Invariant Sections, in the notice that says that the Document is released under this License. If a section does not fit the above definition of Secondary then it is not allowed to be designated as Invariant. The Document may contain zero Invariant Sections. If the Document does not identify any Invariant Sections then there are none.</p>
+
+        <p>The <q>Cover Texts</q> are certain short passages of text that are listed, as Front-Cover Texts or Back-Cover Texts, in the notice that says that the Document is released under this License. A Front-Cover Text may be at most 5 words, and a Back-Cover Text may be at most 25 words.</p>
+
+        <p>A <q>Transparent</q> copy of the Document means a machine-readable copy, represented in a format whose specification is available to the general public, that is suitable for revising the document straightforwardly with generic text editors or (for images composed of pixels) generic paint programs or (for drawings) some widely available drawing editor, and that is suitable for input to text formatters or for automatic translation to a variety of formats suitable for input to text formatters. A copy made in an otherwise Transparent file format whose markup, or absence of markup, has been arranged to thwart or discourage subsequent modification by readers is not Transparent. An image format is not Transparent if used for any substantial amount of text. A copy that is not <q>Transparent</q> is called <q>Opaque</q>.</p>
+
+        <p>Examples of suitable formats for Transparent copies include plain ASCII without markup, Texinfo input format, LaTeX input format, SGML or XML using a publicly available DTD, and standard-conforming simple HTML, PostScript or PDF designed for human modification. Examples of transparent image formats include PNG, XCF and JPG. Opaque formats include proprietary formats that can be read and edited only by proprietary word processors, SGML or XML for which the DTD and/or processing tools are not generally available, and the machine-generated HTML, PostScript or PDF produced by some word processors for output purposes only.</p>
+
+        <p>The <q>Title Page</q> means, for a printed book, the title page itself, plus such following pages as are needed to hold, legibly, the material this License requires to appear in the title page. For works in formats which do not have any title page as such, <q>Title Page</q> means the text near the most prominent appearance of the work's title, preceding the beginning of the body of the text.</p>
+
+        <p>The <q>publisher</q> means any person or entity that distributes copies of the Document to the public.</p>
+
+        <p>A section <q>Entitled XYZ</q> means a named subunit of the Document whose title either is precisely XYZ or contains XYZ in parentheses following text that translates XYZ in another language. (Here XYZ stands for a specific section name mentioned below, such as <q>Acknowledgements</q>, <q>Dedications</q>, <q>Endorsements</q>, or <q>History</q>.) To <q>Preserve the Title</q> of such a section when you modify the Document means that it remains a section <q>Entitled XYZ</q> according to this definition.</p>
+
+        <p>The Document may include Warranty Disclaimers next to the notice which states that this License applies to the Document. These Warranty Disclaimers are considered to be included by reference in this License, but only as regards disclaiming warranties: any other implication that these Warranty Disclaimers may have is void and has no effect on the meaning of this License.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section2">
+        <title>2. VERBATIM COPYING</title>
+
+        <p>You may copy and distribute the Document in any medium, either commercially or noncommercially, provided that this License, the copyright notices, and the license notice saying this License applies to the Document are reproduced in all copies, and that you add no other conditions whatsoever to those of this License. You may not use technical measures to obstruct or control the reading or further copying of the copies you make or distribute. However, you may accept compensation in exchange for copies. If you distribute a large enough number of copies you must also follow the conditions in section 3.</p>
+
+        <p>You may also lend copies, under the same conditions stated above, and you may publicly display copies.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section3">
+        <title>3. COPYING IN QUANTITY</title>
+
+        <p>If you publish printed copies (or copies in media that commonly have printed covers) of the Document, numbering more than 100, and the Document's license notice requires Cover Texts, you must enclose the copies in covers that carry, clearly and legibly, all these Cover Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on the back cover. Both covers must also clearly and legibly identify you as the publisher of these copies. The front cover must present the full title with all words of the title equally prominent and visible. You may add other material on the covers in addition. Copying with changes limited to the covers, as long as they preserve the title of the Document and satisfy these conditions, can be treated as verbatim copying in other respects.</p>
+
+        <p>If the required texts for either cover are too voluminous to fit legibly, you should put the first ones listed (as many as fit reasonably) on the actual cover, and continue the rest onto adjacent pages.</p>
+
+        <p>If you publish or distribute Opaque copies of the Document numbering more than 100, you must either include a machine-readable Transparent copy along with each Opaque copy, or state in or with each Opaque copy a computer-network location from which the general network-using public has access to download using public-standard network protocols a complete Transparent copy of the Document, free of added material. If you use the latter option, you must take reasonably prudent steps, when you begin distribution of Opaque copies in quantity, to ensure that this Transparent copy will remain thus accessible at the stated location until at least one year after the last time you distribute an Opaque copy (directly or through your agents or retailers) of that edition to the public.</p>
+
+        <p>It is requested, but not required, that you contact the authors of the Document well before redistributing any large number of copies, to give them a chance to provide you with an updated version of the Document.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section4">
+        <title>4. MODIFICATIONS</title>
+
+        <p>You may copy and distribute a Modified Version of the Document under the conditions of sections 2 and 3 above, provided that you release the Modified Version under precisely this License, with the Modified Version filling the role of the Document, thus licensing distribution and modification of the Modified Version to whoever possesses a copy of it. In addition, you must do these things in the Modified Version:<ol label="A.">
+            <li><p>Use in the Title Page (and on the covers, if any) a title distinct from that of the Document, and from those of previous versions (which should, if there were any, be listed in the History section of the Document). You may use the same title as a previous version if the original publisher of that version gives permission.</p></li>
+
+            <li><p>List on the Title Page, as authors, one or more persons or entities responsible for authorship of the modifications in the Modified Version, together with at least five of the principal authors of the Document (all of its principal authors, if it has fewer than five), unless they release you from this requirement.</p></li>
+
+            <li><p>State on the Title page the name of the publisher of the Modified Version, as the publisher.</p></li>
+
+            <li><p>Preserve all the copyright notices of the Document.</p></li>
+
+            <li><p>Add an appropriate copyright notice for your modifications adjacent to the other copyright notices.</p></li>
+
+            <li><p>Include, immediately after the copyright notices, a license notice giving the public permission to use the Modified Version under the terms of this License, in the form shown in the Addendum below.</p></li>
+
+            <li><p>Preserve in that license notice the full lists of Invariant Sections and required Cover Texts given in the Document's license notice.</p></li>
+
+            <li><p>Include an unaltered copy of this License.</p></li>
+
+            <li><p>Preserve the section Entitled <q>History</q>, Preserve its Title, and add to it an item stating at least the title, year, new authors, and publisher of the Modified Version as given on the Title Page. If there is no section Entitled <q>History</q> in the Document, create one stating the title, year, authors, and publisher of the Document as given on its Title Page, then add an item describing the Modified Version as stated in the previous sentence.</p></li>
+
+            <li><p>Preserve the network location, if any, given in the Document for public access to a Transparent copy of the Document, and likewise the network locations given in the Document for previous versions it was based on.  These may be placed in the <q>History</q> section. You may omit a network location for a work that was published at least four years before the Document itself, or if the original publisher of the version it refers to gives permission.</p></li>
+
+            <li><p>For any section Entitled <q>Acknowledgements</q> or <q>Dedications</q>, Preserve the Title of the section, and preserve in the section all the substance and tone of each of the contributor acknowledgements and/or dedications given therein.</p></li>
+
+            <li><p>Preserve all the Invariant Sections of the Document, unaltered in their text and in their titles. Section numbers or the equivalent are not considered part of the section titles.</p></li>
+
+            <li><p>Delete any section Entitled <q>Endorsements</q>. Such a section may not be included in the Modified Version.</p></li>
+
+            <li><p>Do not retitle any existing section to be Entitled <q>Endorsements</q> or to conflict in title with any Invariant Section.</p></li>
+
+            <li><p>Preserve any Warranty Disclaimers.</p></li>
+        </ol></p>
+
+        <p>If the Modified Version includes new front-matter sections or appendices that qualify as Secondary Sections and contain no material copied from the Document, you may at your option designate some or all of these sections as invariant. To do this, add their titles to the list of Invariant Sections in the Modified Version's license notice. These titles must be distinct from any other section titles.</p>
+
+        <p>You may add a section Entitled <q>Endorsements</q>, provided it contains nothing but endorsements of your Modified Version by various parties <mdash /> for example, statements of peer review or that the text has been approved by an organization as the authoritative definition of a standard.</p>
+
+        <p>You may add a passage of up to five words as a Front-Cover Text, and a passage of up to 25 words as a Back-Cover Text, to the end of the list of Cover Texts in the Modified Version. Only one passage of Front-Cover Text and one of Back-Cover Text may be added by (or through arrangements made by) any one entity. If the Document already includes a cover text for the same cover, previously added by you or by arrangement made by the same entity you are acting on behalf of, you may not add another; but you may replace the old one, on explicit permission from the previous publisher that added the old one.</p>
+
+        <p>The author(s) and publisher(s) of the Document do not by this License give permission to use their names for publicity for or to assert or imply endorsement of any Modified Version.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section5">
+        <title>5. COMBINING DOCUMENTS</title>
+
+        <p>You may combine the Document with other documents released under this License, under the terms defined in section 4 above for modified versions, provided that you include in the combination all of the Invariant Sections of all of the original documents, unmodified, and list them all as Invariant Sections of your combined work in its license notice, and that you preserve all their Warranty Disclaimers.</p>
+
+        <p>The combined work need only contain one copy of this License, and multiple identical Invariant Sections may be replaced with a single copy. If there are multiple Invariant Sections with the same name but different contents, make the title of each such section unique by adding at the end of it, in parentheses, the name of the original author or publisher of that section if known, or else a unique number. Make the same adjustment to the section titles in the list of Invariant Sections in the license notice of the combined work.</p>
+
+        <p>In the combination, you must combine any sections Entitled <q>History</q> in the various original documents, forming one section Entitled <q>History</q>; likewise combine any sections Entitled <q>Acknowledgements</q>, and any sections Entitled <q>Dedications</q>. You must delete all sections Entitled <q>Endorsements</q>.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section6">
+        <title>6. COLLECTIONS OF DOCUMENTS</title>
+
+        <p>You may make a collection consisting of the Document and other documents released under this License, and replace the individual copies of this License in the various documents with a single copy that is included in the collection, provided that you follow the rules of this License for verbatim copying of each of the documents in all other respects.</p>
+
+        <p>You may extract a single document from such a collection, and distribute it individually under this License, provided you insert a copy of this License into the extracted document, and follow this License in all other respects regarding verbatim copying of that document.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section7">
+        <title>7. AGGREGATION WITH INDEPENDENT WORKS</title>
+
+        <p>A compilation of the Document or its derivatives with other separate and independent documents or works, in or on a volume of a storage or distribution medium, is called an <q>aggregate</q> if the copyright resulting from the compilation is not used to limit the legal rights of the compilation's users beyond what the individual works permit. When the Document is included in an aggregate, this License does not apply to the other works in the aggregate which are not themselves derivative works of the Document.</p>
+
+        <p>If the Cover Text requirement of section 3 is applicable to these copies of the Document, then if the Document is less than one half of the entire aggregate, the Document's Cover Texts may be placed on covers that bracket the Document within the aggregate, or the electronic equivalent of covers if the Document is in electronic form. Otherwise they must appear on printed covers that bracket the whole aggregate.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section8">
+    <title>8. TRANSLATION</title>
+
+        <p>Translation is considered a kind of modification, so you may distribute translations of the Document under the terms of section 4. Replacing Invariant Sections with translations requires special permission from their copyright holders, but you may include translations of some or all Invariant Sections in addition to the original versions of these Invariant Sections. You may include a translation of this License, and all the license notices in the Document, and any Warranty Disclaimers, provided that you also include the original English version of this License and the original versions of those notices and disclaimers. In case of a disagreement between the translation and the original version of this License or a notice or disclaimer, the original version will prevail.</p>
+
+        <p>If a section in the Document is Entitled <q>Acknowledgements</q>, <q>Dedications</q>, or <q>History</q>, the requirement (section 4) to Preserve its Title (section 1) will typically require changing the actual title.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section9">
+        <title>9. TERMINATION</title>
+
+        <p>You may not copy, modify, sublicense, or distribute the Document except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, or distribute it is void, and will automatically terminate your rights under this License.</p>
+
+        <p>However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.</p>
+
+        <p>Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.</p>
+
+        <p>Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, receipt of a copy of some or all of the same material does not give you any rights to use it.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section10">
+        <title>10. FUTURE REVISIONS OF THIS LICENSE</title>
+
+        <p>The Free Software Foundation may publish new, revised versions of the GNU Free Documentation License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. See <url href="http://www.gnu.org/copyleft/" />.</p>
+
+        <p>Each version of the License is given a distinguishing version number. If the Document specifies that a particular numbered version of this License <q>or any later version</q> applies to it, you have the option of following the terms and conditions either of that specified version or of any later version that has been published (not as a draft) by the Free Software Foundation. If the Document does not specify a version number of this License, you may choose any version ever published (not as a draft) by the Free Software Foundation. If the Document specifies that a proxy can decide which future versions of this License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Document.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-section11">
+        <title>11. RELICENSING</title>
+
+        <p><q>Massive Multiauthor Collaboration Site</q> (or <q>MMC Site</q>) means any World Wide Web server that publishes copyrightable works and also provides prominent facilities for anybody to edit those works. A public wiki that anybody can edit is an example of such a server. A <q>Massive Multiauthor Collaboration</q> (or <q>MMC</q>) contained in the site means any set of copyrightable works thus published on the MMC site.</p>
+
+        <p><q>CC-BY-SA</q> means the Creative Commons Attribution-Share Alike 3.0 license published by Creative Commons Corporation, a not-for-profit corporation with a principal place of business in San Francisco, California, as well as future copyleft versions of that license published by that same organization.</p> <p><q>Incorporate</q> means to publish or republish a Document, in whole or in part, as part of another Document.</p>
+
+        <p>An MMC is <q>eligible for relicensing</q> if it is licensed under this License, and if all works that were first published under this License somewhere other than this MMC, and subsequently incorporated in whole or in part into the MMC, (1) had no cover texts or invariant sections, and (2) were thus incorporated prior to November 1, 2008.</p>
+
+        <p>The operator of an MMC Site may republish an MMC contained in the site under CC-BY-SA on the same site at any time before August 1, 2009, provided the MMC is eligible for relicensing.</p>
+    </paragraphs>
+
+    <paragraphs xml:id="gfdl-addendum">
+        <title>ADDENDUM: How to use this License for your documents</title>
+
+        <p>To use this License in a document you have written, include a copy of the License in the document and put the following copyright and license notices just after the title page:</p>
+
+        <pre>
+        Copyright (C)  YEAR  YOUR NAME.
+        Permission is granted to copy, distribute and/or modify this document
+        under the terms of the GNU Free Documentation License, Version 1.3
+        or any later version published by the Free Software Foundation;
+        with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+        A copy of the license is included in the section entitled "GNU
+        Free Documentation License".
+        </pre>
+
+        <p>If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts, replace the <q>with<ellipsis /> Texts.</q> line with this:</p>
+
+        <pre>
+        with the Invariant Sections being LIST THEIR TITLES, with the
+        Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+        </pre>
+
+        <p>If you have Invariant Sections without Cover Texts, or some other combination of the three, merge those two alternatives to suit the situation.</p>
+
+        <p>If your document contains nontrivial examples of program code, we recommend releasing these examples in parallel under your choice of free software license, such as the GNU General Public License, to permit their use in free software.</p>
+    </paragraphs>
+
+</appendix>

--- a/mbx/index.mbx
+++ b/mbx/index.mbx
@@ -92,10 +92,13 @@
 <xi:include href="./app3-expogenfns.mbx" />
 
 
+
 <index>
 <title>Index</title>
 <index-list />
 </index>
+
+<xi:include href="./gfdl-mathbook.mbx" />
 
 </backmatter>
 </book>

--- a/mbx/index.mbx
+++ b/mbx/index.mbx
@@ -91,6 +91,10 @@
 
 <xi:include href="./app3-expogenfns.mbx" />
 
+<appendix>
+    <title>Hints to Selected Problems</title>
+    <solution-list />
+</appendix>
 
 
 <index>

--- a/mbx/s1-2-basics.mbx
+++ b/mbx/s1-2-basics.mbx
@@ -956,8 +956,7 @@ The figure needs to have part (e) added to it.
           Draw the digraph of the function from the set <m>\{</m>Alice, Bob, Dawn,
           Bill<m>\}</m> to the set <m>\{</m>A, B, C, D, E<m>\}</m> given by
           <me>
-            f(X) = \mbox{the first
-            letter of the name \(X\)} .
+            f(X) = \text{ the first letter of the name }X .
           </me>
         </p>
       </statement>
@@ -1783,7 +1782,7 @@ The figure needs to have part (e) added to it.
         <m>\chi</m> is the Greek letter chi that is pronounced Ki, with the
         <m>i</m> sounding like <q>eye.</q></fn>
         <me>
-          \chi_S(i) = \begin{cases}1 \amp \mbox{ if }  i\in S \\ 0 \amp \mbox{ if }  i\not\in
+          \chi_S(i) = \begin{cases}1 \amp \text{ if }  i\in S \\ 0 \amp \text{ if }  i\not\in
           S
           \end{cases}
         </me>

--- a/mbx/s2-4-suppprobs.mbx
+++ b/mbx/s2-4-suppprobs.mbx
@@ -87,7 +87,7 @@
         </p>
         <figure xml:id="butane">
             <caption>A model of a butane molecule</caption>
-            <image>
+            <image width="45%">
                 <latex-image-code>
 \chemfig{H-[:0]C(-[:90]H)(-[:270]H)-[:0]C(-[:90]H)(-[:270]H)-[:0]C(-[:90]H)(-[:270]H)-[:0]C(-[:90]H)(-[:270]H)-[:0]H}
                 </latex-image-code>

--- a/mbx/s5-2-apps.mbx
+++ b/mbx/s5-2-apps.mbx
@@ -25,7 +25,7 @@
             we are asking for the number of distributions of apples that lie in none of the sets, so we are asking for <m>|\overline{A_1\cup A_2\cup \cdots \cup A_n}|</m>. From the formula you gave in
             <xref ref="compunion" /> we see that to find this number we need to know
             <m>|\bigcap_{i\in S}A_i|</m> for every subset <m>S</m> of <m>[n]</m>. But if
-            <m>S</m> has size <m>s</m>, then <m>S</m> determines a distribution such that all the children in a particular set of size <m>s</m> will get five or more apples. By <xref ref="k-obj-n-recip" />, we can pass out the apples so that the children in a particular set 
+            <m>S</m> has size <m>s</m>, then <m>S</m> determines a distribution such that all the children in a particular set of size <m>s</m> will get five or more apples. By <xref ref="k-obj-n-recip" />, we can pass out the apples so that the children in a particular set
             <m>\hat S</m> of children get at least five apples as follows: we give everyone in <m>\hat
             S</m> five apples, and then pass out the remaining <m>k-5s</m> apples to the
             children in <m>\binom{k-5s+n-1}{k-5s}= \binom{k-5s+n-1}{n-1}</m> ways. This
@@ -249,7 +249,7 @@
         <task>
             <statement>
                 <p>
-                   What is the probability that we get a sequence in which all six numbers between one and six appear? To get a numerical answer, you will likely need a computer algebra package, programmable calculator, or spreadsheet. 
+                   What is the probability that we get a sequence in which all six numbers between one and six appear? To get a numerical answer, you will likely need a computer algebra package, programmable calculator, or spreadsheet.
                 </p>
             </statement>
             <solution>

--- a/mbx/s6-2-groupsact.mbx
+++ b/mbx/s6-2-groupsact.mbx
@@ -8,7 +8,7 @@
     </p>
     <figure xml:id="rotate-square">
         <caption>The results on the sides and diagonals of rotating the square</caption>
-        <sidebyside widths="19% 19% 19% 19% 19%" margins="auto">
+        <sidebyside widths="19% 19% 19% 19% 19%" margins="auto" valign="top">
             <image>
                 <latex-image-code>
                     \begin{tikzpicture}
@@ -416,7 +416,7 @@
     </p>
     <figure xml:id="colored-square">
         <caption>The colored square with coloring <m>\left\{(1,R),(2,R),(3,B),(4,B)\right\}</m></caption>
-        <image>
+        <image width="30%">
             <latex-image-code>
                 \begin{tikzpicture}
                 \draw (0,0) -- (0,2) -- (2,2) -- (2,0) -- (0,0);
@@ -818,7 +818,7 @@ and is denoted by <m>Gx_{\text{multi}}</m>.
         </solution>
     </activity>
 
-    <p>We suggested earlier that a quotient principle for multisets might prove useful. The quotient principle came from the sum principle, and we do not have a sum principle for multisets. Such a principle would say that the size of a union of disjoint multisets is the sum of their sizes. We have not yet defined the union of multisets or disjoint multisets, because we haven't needed the ideas until now. We define the <term>union</term><idx><h>union of multisets</h></idx> <idx><h>multisets</h><h>union</h></idx>of two multisets <m>S</m> and <m>T</m> to be the multiset in which the multiplicity of an element <m>x</m> is the maximum<fn>We choose the maximum rather than the sum so that the union of sets is a special case of the union of multisets.</fn> of the multiplicity of <m>x</m> in <m>S</m> and its multiplicity in <m>T</m> . Similarly, the union of a family of multisets is defined by defining the multiplicity of an element <m>x</m> to be the maximum of its multiplicities in the members of the family. 
+    <p>We suggested earlier that a quotient principle for multisets might prove useful. The quotient principle came from the sum principle, and we do not have a sum principle for multisets. Such a principle would say that the size of a union of disjoint multisets is the sum of their sizes. We have not yet defined the union of multisets or disjoint multisets, because we haven't needed the ideas until now. We define the <term>union</term><idx><h>union of multisets</h></idx> <idx><h>multisets</h><h>union</h></idx>of two multisets <m>S</m> and <m>T</m> to be the multiset in which the multiplicity of an element <m>x</m> is the maximum<fn>We choose the maximum rather than the sum so that the union of sets is a special case of the union of multisets.</fn> of the multiplicity of <m>x</m> in <m>S</m> and its multiplicity in <m>T</m> . Similarly, the union of a family of multisets is defined by defining the multiplicity of an element <m>x</m> to be the maximum of its multiplicities in the members of the family.
     Two multisets are said to be <term>disjoint</term><idx><h>disjoint</h><h>multisets</h></idx> if no element is a member of both, that is, if no element has multiplicity one or more in both. Since the size of a multiset is the sum of the multiplicities of its members, we immediately get the <term>sum principle for multisets</term>.<idx><h>sum principle</h><h>for multisets</h></idx>
     </p>
     <blockquote>
@@ -832,7 +832,7 @@ and is denoted by <m>Gx_{\text{multi}}</m>.
     </p>
     <blockquote>
         <p>
-            The union of a set of <m>m</m> disjoint multisets, each of size <m>n</m> has size <m>mn</m>. 
+            The union of a set of <m>m</m> disjoint multisets, each of size <m>n</m> has size <m>mn</m>.
         </p>
     </blockquote>
     <p>

--- a/xsl/custom-common.xsl
+++ b/xsl/custom-common.xsl
@@ -63,21 +63,21 @@
 <!-- A task is a division of a project         -->
 <xsl:param name="project.text.statement" select="'yes'" /> <!-- not implemented -->
 <xsl:param name="project.text.hint" select="'yes'" />
-<xsl:param name="project.text.answer" select="'yes'" />
-<xsl:param name="project.text.solution" select="'yes'" />
+<xsl:param name="project.text.answer" select="'no'" />
+<xsl:param name="project.text.solution" select="'no'" />
 <xsl:param name="task.text.statement" select="'yes'" /> <!-- not implemented -->
 <xsl:param name="task.text.hint" select="'yes'" />
-<xsl:param name="task.text.answer" select="'yes'" />
-<xsl:param name="task.text.solution" select="'yes'" />
+<xsl:param name="task.text.answer" select="'no'" />
+<xsl:param name="task.text.solution" select="'no'" />
 <!-- And project-like elements, in back matter (none implemented). -->
-<xsl:param name="project.backmatter.statement" select="'yes'" />
+<xsl:param name="project.backmatter.statement" select="'no'" />
 <xsl:param name="project.backmatter.hint" select="'yes'" />
-<xsl:param name="project.backmatter.answer" select="'yes'" />
-<xsl:param name="project.backmatter.solution" select="'yes'" />
-<xsl:param name="task.backmatter.statement" select="'yes'" />
+<xsl:param name="project.backmatter.answer" select="'no'" />
+<xsl:param name="project.backmatter.solution" select="'no'" />
+<xsl:param name="task.backmatter.statement" select="'no'" />
 <xsl:param name="task.backmatter.hint" select="'yes'" />
-<xsl:param name="task.backmatter.answer" select="'yes'" />
-<xsl:param name="task.backmatter.solution" select="'yes'" />
+<xsl:param name="task.backmatter.answer" select="'no'" />
+<xsl:param name="task.backmatter.solution" select="'no'" />
 <!-- Author tools are for drafts, mostly "todo" items                 -->
 <!-- and "provisional" citations and cross-references                 -->
 <!-- Default is to hide todo's, inline provisionals                   -->

--- a/xsl/custom-latex.xsl
+++ b/xsl/custom-latex.xsl
@@ -126,12 +126,14 @@
 <xsl:param name="exercise.text.statement" select="'yes'" />
 <xsl:param name="exercise.text.hint" select="'yes'" />
 <xsl:param name="exercise.text.answer" select="'no'" />
-<xsl:param name="exercise.text.solution" select="'yes'" />
+<xsl:param name="exercise.text.solution" select="'no'" />
 <xsl:param name="exercise.backmatter.statement" select="'no'" />
 <xsl:param name="exercise.backmatter.hint" select="'no'" />
-<xsl:param name="exercise.backmatter.answer" select="'yes'" />
-<xsl:param name="exercise.backmatter.solution" select="'yes'" />
+<xsl:param name="exercise.backmatter.answer" select="'no'" />
+<xsl:param name="exercise.backmatter.solution" select="'no'" />
 
+<xsl:param name="project.text.hint" select="'no'" />
+<xsl:param name="task.text.hint" select="'no'" />
 
 
 <!-- Include a style file at the end of the preamble: -->
@@ -380,6 +382,57 @@
         </xsl:when>
     </xsl:choose>
 </xsl:template>
+
+
+
+<!-- Hack backmatter to get hints to projects and tasks: -->
+
+
+<xsl:template match="solution-list">
+    <!-- TODO: check here once for backmatter switches set to "knowl", which is unrealizable -->
+    <!-- <xsl:apply-templates select="activity" mode="backmatter" /> -->
+    <xsl:text>\begin{itemize}[itemsep=1em]&#xa;</xsl:text>
+   <xsl:apply-templates select="//activity" mode="backmatter"/>
+   <xsl:text>\end{itemize}&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="activity" mode="backmatter">
+  <xsl:if test="hint and $project.backmatter.hint='yes'">
+        <!-- Lead with the problem number and some space -->
+    <xsl:text>\item[\textbf{</xsl:text>
+    <xsl:apply-templates select="." mode="serial-number" />
+    <xsl:text>}.]</xsl:text>
+    <xsl:apply-templates select="hint" mode="backmatter" />
+  </xsl:if>
+  <xsl:apply-templates select="task" mode="backmatter" />
+</xsl:template>
+
+
+<xsl:template match="task" mode="backmatter">
+  <xsl:if test="hint and $task.backmatter.hint='yes'">
+        <!-- Lead with the problem number and some space -->
+    <xsl:text>\item[\textbf{</xsl:text>
+    <xsl:apply-templates select="." mode="number" />
+    <xsl:text>}.]</xsl:text>
+    <xsl:apply-templates select="hint" mode="backmatter" />
+  </xsl:if>
+  <xsl:apply-templates select="task" mode="backmatter" />
+</xsl:template>
+
+
+<!-- We print hints, answers, solutions with no heading. -->
+<!-- TODO: make heading on solution components configurable -->
+<xsl:template match="hint" mode="backmatter">
+    <xsl:apply-templates />
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
+<xsl:template match="hint[2]" mode="backmatter">
+    <xsl:text>\par\smallskip&#xa;\noindent\textbf{Additional Hint}: </xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>&#xa;</xsl:text>
+</xsl:template>
+
 
 
 </xsl:stylesheet>


### PR DESCRIPTION
I've thrown together some xsl in custom-latex.xsl that allows hints to show up in the backmatter.  This is a temporary fix until Rob implements this for projects and tasks.  Right now it only works for LaTeX, but since we will knowl hints in html, I think this is fine.

I've also included the GFDL section after the index.