### PR TITLE
Remove the addendum from GFDL and rename file to move from MBX to PTX.

### DIFF
--- a/gfdl-pretext.ptx
+++ b/gfdl-pretext.ptx
@@ -200,32 +200,4 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 
         <p>The operator of an MMC Site may republish an MMC contained in the site under CC-BY-SA on the same site at any time before August 1, 2009, provided the MMC is eligible for relicensing.</p>
     </paragraphs>
-
-    <paragraphs xml:id="gfdl-addendum">
-        <title>ADDENDUM: How to use this License for your documents</title>
-
-        <p>To use this License in a document you have written, include a copy of the License in the document and put the following copyright and license notices just after the title page:</p>
-
-        <pre>
-        Copyright (C)  YEAR  YOUR NAME.
-        Permission is granted to copy, distribute and/or modify this document
-        under the terms of the GNU Free Documentation License, Version 1.3
-        or any later version published by the Free Software Foundation;
-        with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
-        A copy of the license is included in the section entitled "GNU
-        Free Documentation License".
-        </pre>
-
-        <p>If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts, replace the <q>with<ellipsis /> Texts.</q> line with this:</p>
-
-        <pre>
-        with the Invariant Sections being LIST THEIR TITLES, with the
-        Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
-        </pre>
-
-        <p>If you have Invariant Sections without Cover Texts, or some other combination of the three, merge those two alternatives to suit the situation.</p>
-
-        <p>If your document contains nontrivial examples of program code, we recommend releasing these examples in parallel under your choice of free software license, such as the GNU General Public License, to permit their use in free software.</p>
-    </paragraphs>
-
 </appendix>

--- a/mbx/index.mbx
+++ b/mbx/index.mbx
@@ -149,7 +149,7 @@ Ken's career was characterized by a love of mathematics and scholarship, and a p
     <solution-list />
 </appendix>
 
-<xi:include href="./gfdl-mathbook.mbx" />
+<xi:include href="./gfdl-pretext.ptx" />
 
 <index>
 <title>Index</title>


### PR DESCRIPTION
I'm pretty sure that we don't need to distribute the addendum on how to use the GFDL in your own documents, so I've stripped it from this file. This has positive effects when reducing the font size for the GFDL appendix in the final LaTeX version to footnotesize.